### PR TITLE
fix: fix typos in tests of css selectors builder subtask

### DIFF
--- a/test/objects-tests.js
+++ b/test/objects-tests.js
@@ -437,7 +437,7 @@ describe('objects-tasks', () => {
   );
 
   it.optional(
-    'cssSelectorBuilder should creates css selector object with stringify() method',
+    'cssSelectorBuilder should create css selector object with stringify() method',
     () => {
       const builder = tasks.cssSelectorBuilder;
 
@@ -583,9 +583,9 @@ describe('objects-tasks', () => {
       ].forEach((fn) => {
         assert.throws(
           fn,
-          /Element, id and pseudo-element should not occur more then one time inside the selector/,
+          /Element, id and pseudo-element should not occur more than one time inside the selector/,
 
-          '\nPlease throw an exception "Element, id and pseudo-element should not occur more then one time inside the selector" ' +
+          '\nPlease throw an exception "Element, id and pseudo-element should not occur more than one time inside the selector" ' +
             'if element, id or pseudo-element occurs twice or more times'
         );
       });
@@ -597,7 +597,7 @@ describe('objects-tasks', () => {
       ].forEach((fn) => {
         assert.doesNotThrow(
           fn,
-          /Element, id and pseudo-element should not occur more then one time inside the selector/
+          /Element, id and pseudo-element should not occur more than one time inside the selector/
         );
       });
 


### PR DESCRIPTION
#### Title of Pull Request

Fix typos in tests of css selectors builder subtask

#### 🤔 This is a ...

- [ ] 🌟 New task
- [ ] 🌐 New module
- [ ] ⚙️ Update to an existing task
- [ ] 🔧 Update to an existing module
- [ ] 🔗 Update or addition of external resources or links
- [ ] 🐛 Fix in a task or related content
- [ ] 🛠 Fix in a module or related content
- [x] ✏️ Fixed a typo or grammatical error
- [ ] 🔗 Fixed a broken link
- [ ] ❓ Other (specify: **\*\*\*\***\_\_\_\_**\*\*\*\***)

#### Description

- **Brief Overview:**
 Clarified the spelling of the verb 'create' after 'should'. Corrected 'then' to 'than' to align with the intended meaning of the exception text, ensuring consistency with the rule that an element, ID, or pseudo-element should not occur more than once inside the selector.

#### Additional Information

- **Screenshots/Links:**
  <!-- 📸 Include any relevant screenshots or links to documentation or discussions -->
- [ ] Related Issues:
<!-- 🔗 Mention any related issues or pull requests if applicable -->

#### Checklist

- [ ] ✅ I have performed a self-review of my own code.
- [ ] 📝 I have commented my code, particularly in hard-to-understand areas.
- [ ] 🔧 I have made corresponding changes to the documentation (if applicable).
- [ ] 🚫 My changes generate no new warnings or errors.
